### PR TITLE
Fix corner case when disabled option is selected

### DIFF
--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -1988,14 +1988,33 @@ export default class SelecticStore {
             this.hasValue(value)
         );
 
+        /* Whether at least one option, that is not disabled, is not selected. */
+        const hasAvailableNonSelectedOptions = state.allOptions.filter((opt) => {
+            const isOptionNotSelected = !(Array.isArray(selectedOptions)
+                ? selectedOptions.some((selectedOpt) => selectedOpt.id == opt.id)
+                : selectedOptions && selectedOptions.id == opt.id)
+
+            return isOptionNotSelected && !opt.disabled;
+        }).length > 0;
+
         const isEmpty = nbEnabled === 0;
-        const hasOnlyOneOption = nbEnabled === 1 && hasOnlyValidValue && !state.allowClearSelection;
+        const hasOnlyOneOption = (
+            nbEnabled === 1 && hasOnlyValidValue && !state.allowClearSelection
+        );
+
+        /* In most cases if `hasOnlyOneOption` is true, we disable selection.
+         * However, if the only option available is not the selected one then
+         * we do not disable selection (to let the user switch from its current disabled selection,
+         * and a valid one).
+         */
+        const cannotSelectAnyOption = hasOnlyOneOption && !hasAvailableNonSelectedOptions;
+
         const isExclusiveDisabledItem = Array.isArray(selectedOptions) /* which means "multiple" mode */
             && selectedOptions.length === 1
             && selectedOptions[0].exclusive
             && selectedOptions[0].disabled;
 
-        if (hasOnlyOneOption || isEmpty || isExclusiveDisabledItem) {
+        if (cannotSelectAnyOption || isEmpty || isExclusiveDisabledItem) {
             if (state.isOpen) {
                 this.setAutomaticClose();
                 this.commit('isOpen', false);

--- a/test/Store/Store_props.spec.js
+++ b/test/Store/Store_props.spec.js
@@ -229,6 +229,70 @@ tape.test('change props', (subT) => {
                 t.end();
             });
 
+            sTest.test('should not disable the select, if a disabled option is selected and there is an ' +
+                       'option available', async (t) => {
+                const options = getOptions(2, 'alpha');
+                options[1].disabled = true;
+
+                const store = new Store({
+                    value: 1,
+                    options: options,
+                    disabled: false,
+                    params: {
+                        autoDisabled: true,
+                    },
+                });
+                await _.nextVueTick(store);
+
+                t.is(store.state.selectedOptions.text, 'alpha1');
+                t.is(store.state.internalValue, 1);
+                t.is(store.state.disabled, false);
+
+                /* Once we choose the only valid option, disable the selection */
+                store.props.value = 0;
+                await _.nextVueTick(store);
+
+                t.is(store.state.selectedOptions.text, 'alpha0');
+                t.is(store.state.internalValue, 0);
+                t.is(store.state.disabled, true);
+
+                t.end();
+            });
+
+            sTest.test('should not disable the select, if disabled options are selected and there is an ' +
+                       'option available (multi select)', async (t) => {
+                const options = getOptions(3, 'alpha');
+                options[1].disabled = true;
+                options[2].disabled = true;
+
+                const store = new Store({
+                    value: [1, 2],
+                    options: options,
+                    disabled: false,
+                    params: {
+                        autoDisabled: true,
+                        multiple: true,
+                    },
+                });
+                await _.nextVueTick(store);
+
+                t.deepEqual(store.state.internalValue, [1, 2]);
+                t.is(store.state.disabled, false);
+
+                store.props.value = [0];
+                await _.nextVueTick(store);
+
+                /* 0 selected
+                 * 1 disabled
+                 * 2 disabled
+                 */
+
+                t.deepEqual(store.state.internalValue, [0]);
+                t.is(store.state.disabled, true);
+
+                t.end();
+            });
+
             sTest.test('should not disable the select with an invalid value', async (t) => {
                 const store = new Store({
                     value: 2,


### PR DESCRIPTION
It happens that:
- User selects A
- A is later disabled
- Subsequently, opening Selectic shows A as selected but disabled
- Another, non disabled, option is disabled in the menu.

Currently, Selectic is disabled if there is only one non-disabled option. It's a problem if the selected element is a disabled element, and the user wants to select the other (valid) option.

With this patch, if there is one selected disabled option but there is another available option, we do not disable Selectic so the user can choose the other (non-disabled) option. Once the valid option is selected, the user cannot open Selectic's menu anymore (disabled).